### PR TITLE
Remove webcomponentsjs dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,8 +31,7 @@
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.1.4",
     "iron-meta": "PolymerElements/iron-meta#^1.1.2",
-    "elements-demo-resources": "vaadin/elements-demo-resources#master",
-    "webcomponentsjs": "^0.7.23"
+    "elements-demo-resources": "vaadin/elements-demo-resources#master"
   },
   "variants": {
     "polymer2": {
@@ -44,8 +43,7 @@
       "devDependencies": {
         "iron-component-page": "#2.0-preview",
         "iron-meta": "#2.0-preview",
-        "elements-demo-resources": "#2.0-preview",
-        "webcomponentsjs": "#v1"
+        "elements-demo-resources": "#2.0-preview"
       }
     }
   }


### PR DESCRIPTION
It's already included in Polymer:

- https://github.com/Polymer/polymer/blob/1.x/bower.json#L28
- https://github.com/Polymer/polymer/blob/master/bower.json#L25

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-icons/31)
<!-- Reviewable:end -->