### PR TITLE
Filter iconsets so as we only show vaadin collection

### DIFF
--- a/demo/icons-basic-demos.html
+++ b/demo/icons-basic-demos.html
@@ -70,7 +70,7 @@
 
       ready() {
         super.ready();
-        this.iconsets = new Polymer.IronMeta({type: 'iconset'}).list;
+        this.iconsets = new Polymer.IronMeta({type: 'iconset'}).list.filter(i => i.name == 'vaadin');
 
         // Checked in gemini before capture callback
         window.webComponentsAreReady = true;


### PR DESCRIPTION
This fixes the problem in vaadin.com showing all loaded iconsets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-icons/44)
<!-- Reviewable:end -->
