### PR TITLE
Add cheerio devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "homepage": "https://vaadin.com/icons",
   "devDependencies": {
+    "cheerio": "^1.0.0-rc.2",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "gulp-modify": "^0.1.1"


### PR DESCRIPTION
`cheerio` is used in https://github.com/vaadin/vaadin-icons/blob/master/gulpfile.js#L6

I don't know how this was working before, for me `npm install && ./node_modules/.bin/gulp` results with an error about missing `cheerio` module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-icons/71)
<!-- Reviewable:end -->
