### PR TITLE
Remove duplicate demo link in doc viewer

### DIFF
--- a/vaadin-icons.html
+++ b/vaadin-icons.html
@@ -20,7 +20,7 @@
 
  For the complete list of available icons, see https://vaadin.com/icons
  @pseudoElement vaadin-icons
- @demo demo/
+ @demo
  -->
 <iron-iconset-svg name="vaadin" size="16">
 <svg><defs>


### PR DESCRIPTION
Tested locally (after running `polymer analyze vaadin-* > analysis.json`) that this change gets rid of the extra "demo" link in the doc viewer. This will probably also fix it for webcomponents.org

Should fix #43 when there is a new version in webcomponents.org.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-icons/73)
<!-- Reviewable:end -->
