### PR TITLE
chore: disable issues and direct ppl to web-components repo [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Web Components: Bugs and Feature Requests"
+    url: https://github.com/vaadin/web-components/issues/new/choose
+    about: Please report issues related to the TypeScript and HTML API of Vaadin components here.
+  - name: "Flow Components: Bugs and Feature Requests"
+    url: https://github.com/vaadin/flow-components/issues/new/choose
+    about: Please report issues related to the Java API of Vaadin components here.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,15 @@
+# Vaadin Icons
+
+> ⚠️ Starting from Vaadin 20, the source code and issues for this component are migrated to the [`vaadin/web-components`](https://github.com/vaadin/web-components/tree/master/packages/vaadin-icons) monorepository.
+> This repository contains the source code and releases of `<vaadin-icons>` for the Vaadin versions 10 to 19.
+
 [![npm version](https://badgen.net/npm/v/@vaadin/vaadin-icons)](https://www.npmjs.com/package/@vaadin/vaadin-icons)
 [![Bower version](https://badgen.net/github/release/vaadin/vaadin-icons)](https://github.com/vaadin/vaadin-icons/releases)
 [![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://www.webcomponents.org/element/vaadin/vaadin-icons)
 [![Build status](https://travis-ci.org/vaadin/vaadin-icons.svg?branch=master)](https://travis-ci.org/vaadin/vaadin-icons)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/vaadin/web-components?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-
 [![Published on Vaadin Directory](https://img.shields.io/badge/Vaadin%20Directory-published-00b4f0.svg)](https://vaadin.com/directory/component/vaadinvaadin-icons)
 [![Stars on vaadin.com/directory](https://img.shields.io/vaadin-directory/star/vaadinvaadin-icons.svg)](https://vaadin.com/directory/component/vaadinvaadin-icons)
-
-# Vaadin Icons
-
-> ⚠️ 　Starting from Vaadin 20, this project has migrated to [`vaadin-web-components`](https://github.com/vaadin/vaadin-web-components/tree/master/packages/vaadin-icons) *monorepository*.
->
-> This repository is used for Vaadin 14 LTS and Vaadin 19.
-
----
 
 [<img src="https://raw.github.com/vaadin/vaadin-icons/master/screenshot.png" width="611" alt="Screenshot of some icons in the Vaadin Icons collection" />](https://vaadin.com/icons)
 


### PR DESCRIPTION
## Description

All component-related issues (for any version of the component) should be opened either in `the web-components` monorepo (if it's reproducible with TypeScript and HTML, without Vaadin Flow / Java), or in the `flow-components` monorepo (if it's about the Java API). This repository remains open only to be able to release fixes for the versions of this web component used with Vaadin 10, 14 and Vaadin 19 for as long as they are maintained.

In order to make this clear for users, this PR
  - updates the README to make the role of this repo and its relationship with the the `web-components` monorepo very clear
  - disables new issues in this repo: any attempt to create a new issue here would direct users either to the `web-components` or to the `flow-components` monorepo

Related to: https://github.com/vaadin/components-team-tasks/issues/584

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.